### PR TITLE
Make a search for a UUID bring up the profile for said UUID

### DIFF
--- a/src/components/PlayerSearch.vue
+++ b/src/components/PlayerSearch.vue
@@ -183,6 +183,9 @@ export default {
       }
       this.serverQuery = false;
       this.serverName = '';
+      if (this.name.length === 36 && this.name.split('-').length === 5) {
+        this.$router.replace(`/player/${this.name}`);
+      }
       if (this.name.includes(':')) {
         const nme = this.name.split(':');
         if (!Number.isNaN((nme[1] * 1))) {


### PR DESCRIPTION
If you search for a UUID in the search bar the website now redirects to that player's profile instead of trying to use the UUID as a name query.