### PR TITLE
Change player search result view from a button list to a tag system

### DIFF
--- a/src/components/PlayerTag.vue
+++ b/src/components/PlayerTag.vue
@@ -1,0 +1,32 @@
+<template>
+  <div>
+    <v-card height="max(13.5vw,75px)">
+      <img :src="`https://crafatar.com/avatars/${UUID}?size=300&overlay`"
+      style="width:75%;
+      margin-left:12.5%;
+      padding-top:12.5%;">
+        <p
+        style="
+        font-size: max(1vw,5pt);
+        text-align:center;">
+          {{title}}
+        </p>
+    </v-card>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'PlayerTag',
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    UUID: {
+      type: String,
+      required: true,
+    },
+  },
+};
+</script>


### PR DESCRIPTION
I keep calling them Tags though I'm unsure if that's right, the amount of players on one page is now 50 as 20 with the new system looked off, this new system has cards for each player with their face and their title (ranks then name) below it, I think this is much nicer and easier to quickly identify who you're looking for.