### PR TITLE
Make the player search utilize the new ability for the api to handle an array for `searchPlayerName`

### DIFF
--- a/src/components/PlayerSearch.vue
+++ b/src/components/PlayerSearch.vue
@@ -128,10 +128,11 @@ export default {
       this.preTests();
       const page = (this.pageNum <= 0) ? 1 : this.pageNum;
       const searchName = this.cleanUpSearchString(this.searchString);
+      const searchNameArr = searchName.split(" ").map(elm => {return `"%${elm}%"`});
       const newPlayers = await this.$apollo.query({
         query: (!this.serverQuery) ? gql`
         query {
-          players(searchPlayerName:"%${searchName}%", limit:20, offset:${(page - 1) * 20}){
+          players(searchPlayerName:[${searchNameArr}], matchAll: true, limit:20, offset:${(page - 1) * 20}){
             totalCount
             result{
               lastSeenName


### PR DESCRIPTION
**This cannot be merged until https://github.com/Tallcraft/tc-api-server/pull/50 is merged, it relies on changes to the API made in that PR**

Very simple change, just makes the search use a string array and splits on spaces so you can now search for "that luke" or "bob uncle" and gets results you more or less expect. As of right now both those searches would turn up nothing.

While the changes made in https://github.com/Tallcraft/tc-api-server/pull/50 allows for matching *any* of the elements of the `searchPlayerName` array, this change only uses the match all functionality for now as I'm not sure how to cleanly allow for the end user to select which they'd like.